### PR TITLE
Fix/recipes

### DIFF
--- a/custom-recipes/decision-tree-builder-tree-evaluation/recipe.json
+++ b/custom-recipes/decision-tree-builder-tree-evaluation/recipe.json
@@ -8,12 +8,12 @@
 
     "kind" : "PYTHON",
 
-    "selectableFromDataset": "input_dataset",
+    "selectableFromDataset": "inputDataset",
     "selectableFromFolder": "folder",
 
     "inputRoles" : [
         {
-            "name": "input_dataset",
+            "name": "inputDataset",
             "label": "Input dataset",
             "arity": "UNARY",
             "required": true,
@@ -33,14 +33,14 @@
 
     "outputRoles" : [
         {
-            "name": "scored_dataset",
+            "name": "scoredDataset",
             "label": "Scored dataset",
             "arity": "UNARY",
             "required": true,
             "acceptsDataset": true
         },
         {
-            "name": "metrics_dataset",
+            "name": "metricsDataset",
             "label": "Metrics dataset",
             "arity": "UNARY",
             "required": true,
@@ -51,37 +51,51 @@
 
     "params": [
         {
-            "name": "tree_file",
+            "name": "treeFile",
             "label" : "Decision tree",
             "type": "STRING",
             "description": "Name of the JSON file, including the extension",
             "mandatory" : true
         },
         {
-            "name" : "chunk_size",
-            "label" : "Chunk size",
-            "type": "INT",
-            "description":"Size of each chunk when scoring the dataset",
-            "mandatory" : false,
-            "defaultValue": 10000
+            "label": "Additional columns",
+            "type": "SEPARATOR"
         },
         {
-            "name": "probabilities",
+            "name": "outputProbabilities",
             "label" : "Output probabilities",
             "type": "BOOLEAN",
             "defaultValue" : true,
-            "description" : "output probabilities for each class in addition to the prediction "
+            "description" : "output probabilities for each class in addition to the prediction"
+        },
+        {
+            "name": "checkPrediction",
+            "label" : "Check if prediction is correct",
+            "defaultValue" : true,
+            "type": "BOOLEAN"
+        },
+        {
+            "name": "keepSomeColumns",
+            "label" : "Input columns to include",
+            "type": "BOOLEAN",
+            "description" : "avoid copying the whole input dataset to the output "
+        },
+        {
+            "name": "inputColumns",
+            "label": "Columns to keep",
+            "type": "COLUMNS",
+            "visibilityCondition" : "model.keepSomeColumns",
+            "columnRole": "inputDataset"
+        },
+        {
+            "label": "Computed metrics",
+            "type": "SEPARATOR"
         },
         {
             "name": "filterMetrics",
             "label" : "Filter metrics",
             "type": "BOOLEAN",
-            "description" : "select a subset of available metrics to evaluate"
-        },
-        {
-            "label": "Available metrics",
-            "type": "SEPARATOR",
-            "visibilityCondition" : "model.filterMetrics"
+            "description" : "select only a subset of available metrics to evaluate"
         },
         {
             "name": "auc",

--- a/custom-recipes/decision-tree-builder-tree-evaluation/recipe.py
+++ b/custom-recipes/decision-tree-builder-tree-evaluation/recipe.py
@@ -18,7 +18,7 @@ except ValueError:
 tree = ScoringTree(tree_dict["target"], tree_dict["target_values"], tree_dict["nodes"], tree_dict["features"])
 
 columns = recipe_config["inputColumns"] if recipe_config["keepSomeColumns"] else None
-scored_dataset.write_schema(get_scored_df_schema(tree, input_dataset, columns, recipe_config["outputProbabilities"], True, recipe_config["checkPrediction"]))
+scored_dataset.write_schema(get_scored_df_schema(tree, input_dataset.read_schema(), columns, recipe_config["outputProbabilities"], True, recipe_config["checkPrediction"]))
 input_dataframe = input_dataset.get_dataframe()
 input_dataframe.loc[:, tree.target] = input_dataframe.loc[:, tree.target].apply(safe_str)
 add_scoring_columns(tree, input_dataframe, True, True, recipe_config["checkPrediction"])

--- a/custom-recipes/decision-tree-builder-tree-evaluation/recipe.py
+++ b/custom-recipes/decision-tree-builder-tree-evaluation/recipe.py
@@ -1,61 +1,54 @@
 from dataiku.customrecipe import get_input_names_for_role, get_output_names_for_role, get_recipe_config
-import pandas as pd
-from dku_idtb_decision_tree.tree import Tree
-from dku_idtb_scoring.score import score, write_with_schema
+from dku_idtb_decision_tree.tree import ScoringTree
+from dku_idtb_scoring.score import add_scoring_columns, get_scored_df_schema, get_metric_df_schema
 from dku_idtb_compatibility.utils import safe_str
 from dataiku.doctor.prediction.reg_evaluation_recipe import compute_multiclass_metrics, compute_binary_classification_metrics
 
-input_dataset = dataiku.Dataset(get_input_names_for_role("input_dataset")[0])
-scored_dataset = dataiku.Dataset(get_output_names_for_role("scored_dataset")[0])
-metrics_dataset = dataiku.Dataset(get_output_names_for_role("metrics_dataset")[0])
+input_dataset = dataiku.Dataset(get_input_names_for_role("inputDataset")[0])
 folder = dataiku.Folder(get_input_names_for_role("folder")[0])
-chunk_size_param = get_recipe_config()["chunk_size"]
+scored_dataset = dataiku.Dataset(get_output_names_for_role("scoredDataset")[0])
+metrics_dataset = dataiku.Dataset(get_output_names_for_role("metricsDataset")[0])
+recipe_config = get_recipe_config()
 
 try:
-    tree = folder.read_json(get_recipe_config()["tree_file"])
+    tree_dict = folder.read_json(recipe_config["treeFile"])
 except ValueError:
-    raise Exception("No tree file named " + get_recipe_config()["tree_file"])
+    raise Exception("No tree file named " + recipe_config["treeFile"])
 
-tree["df"] = input_dataset.get_dataframe()
-tree = Tree(**tree)
+tree = ScoringTree(tree_dict["target"], tree_dict["target_values"], tree_dict["nodes"], tree_dict["features"])
 
-scored_df = score(tree, input_dataset, chunk_size_param, True)
+columns = recipe_config["inputColumns"] if recipe_config["keepSomeColumns"] else None
+scored_dataset.write_schema(get_scored_df_schema(tree, input_dataset, columns, recipe_config["outputProbabilities"], True, recipe_config["checkPrediction"]))
+input_dataframe = input_dataset.get_dataframe()
+input_dataframe.loc[:, tree.target] = input_dataframe.loc[:, tree.target].apply(safe_str)
+add_scoring_columns(tree, input_dataframe, True, True, recipe_config["checkPrediction"])
+prediction_col_not_na = ~input_dataframe.prediction.isna()
 
-target_mapping = {safe_str(label): index for index, label in enumerate(tree.target_values)}
-scored_df_nona = scored_df.dropna(subset=["prediction"])
-y_actual, y_pred = scored_df_nona[tree.target], scored_df_nona.prediction
-y_actual = y_actual.map(lambda t: int(target_mapping[safe_str(t)]))
-y_pred = y_pred.map(lambda t: int(target_mapping[safe_str(t)]))
-
-if len(tree.target_values) > 2:
-    compute_metrics = compute_multiclass_metrics
-    metrics = ["precision", "recall", "accuracy", "mrocAUC", "logLoss", "hammingLoss", "mcalibrationLoss"]
-else:
-    compute_metrics = compute_binary_classification_metrics
-    metrics = ["precision", "recall", "accuracy", "auc",  "hammingLoss", "logLoss", "calibrationLoss"]
-
-sorted_classes = sorted(target_mapping, key=lambda label: target_mapping[label])
-
-if get_recipe_config()["probabilities"]:
-    probas = scored_df_nona[["proba_" + safe_str(label) for label in sorted_classes]]
-else:
-    probas = pd.DataFrame()
-    for value in sorted_classes:
-        probas["proba_" + value] = scored_df_nona.pop("proba_" + safe_str(value))
-
-metrics_dict = compute_metrics({"metrics": {"evaluationMetric": None, "liftPoint": 0.4}}, y_actual, y_pred, probas.values)
-schema_metrics = []
-for metric in metrics:
-    if metric == "mcalibrationLoss":
-        metric = "calibrationLoss"
-    if metric == "mrocAUC":
-        metric = "auc"
-    if get_recipe_config()["filterMetrics"] and not get_recipe_config()[metric]:
-        metrics_dict.pop(metric, "None")
+if not recipe_config["outputProbabilities"]:
+    import pandas as pd
+    probas_df = pd.DataFrame()
+    for target_value in tree.target_values:
+        probas_df["proba_" + target_value] = input_dataframe.pop("proba_" + safe_str(target_value))[prediction_col_not_na]
+with scored_dataset.get_writer() as writer:
+    if columns is None:
+            writer.write_dataframe(input_dataframe)
     else:
-        schema_metrics.append({"type": "float", "name": metric})
+        writer.write_dataframe(input_dataframe[columns])
 
-write_with_schema(tree, input_dataset, scored_dataset, scored_df_nona, get_recipe_config()["probabilities"], True)
-metrics_dataset.write_schema(schema_metrics)
+input_dataframe = input_dataframe[prediction_col_not_na]
+if recipe_config["outputProbabilities"]:
+    probas_df = input_dataframe[["proba_" + safe_str(target_value) for target_value in tree.target_values]]
+target_mapping = {safe_str(label): index for index, label in enumerate(tree.target_values)}
+y_pred = input_dataframe["prediction"].map(lambda t: int(target_mapping[safe_str(t)]))
+y_actual = input_dataframe[tree.target].map(lambda t: int(target_mapping[safe_str(t)]))
+
+if len(tree.target_values) == 2:
+    metrics_dict = compute_binary_classification_metrics({"metrics": {"evaluationMetric": None, "liftPoint": 0.4}}, y_actual, y_pred, probas_df.values)
+    metrics = ["precision", "recall", "accuracy", "auc",  "hammingLoss", "logLoss", "calibrationLoss"]
+else:
+    metrics_dict = compute_multiclass_metrics({"metrics": {"evaluationMetric": None, "liftPoint": 0.4}}, y_actual, y_pred, probas_df.values)
+    metrics = ["precision", "recall", "accuracy", "mrocAUC", "logLoss", "hammingLoss", "mcalibrationLoss"]
+
+metrics_dataset.write_schema(get_metric_df_schema(metrics_dict, metrics, recipe_config))
 with metrics_dataset.get_writer() as writer:
     writer.write_row_dict(metrics_dict)

--- a/custom-recipes/decision-tree-builder-tree-scoring/recipe.json
+++ b/custom-recipes/decision-tree-builder-tree-scoring/recipe.json
@@ -8,12 +8,12 @@
 
     "kind" : "PYTHON",
 
-    "selectableFromDataset": "input_dataset",
+    "selectableFromDataset": "inputDataset",
     "selectableFromFolder": "folder",
 
     "inputRoles" : [
         {
-            "name": "input_dataset",
+            "name": "inputDataset",
             "label": "Input Dataset",
             "arity": "UNARY",
             "required": true,
@@ -33,7 +33,7 @@
 
     "outputRoles" : [
         {
-            "name": "scored_dataset",
+            "name": "scoredDataset",
             "label": "Scored dataset",
             "arity": "UNARY",
             "required": true,
@@ -44,14 +44,21 @@
 
     "params": [
         {
-            "name": "tree_file",
+            "name": "treeFile",
             "label" : "Decision tree",
             "type": "STRING",
             "description": "Name of the JSON file, including the extension",
             "mandatory" : true
         },
         {
-            "name" : "chunk_size",
+            "name": "outputProbabilities",
+            "label" : "Output probabilities",
+            "type": "BOOLEAN",
+            "defaultValue" : true,
+            "description" : "output probabilities for each class in addition to the prediction"
+        },
+        {
+            "name" : "chunkSize",
             "label" : "Chunk size",
             "type": "INT",
             "description":"Size of each chunk when scoring the dataset",

--- a/custom-recipes/decision-tree-builder-tree-scoring/recipe.py
+++ b/custom-recipes/decision-tree-builder-tree-scoring/recipe.py
@@ -15,7 +15,7 @@ except ValueError:
 tree = ScoringTree(tree_dict["target"], tree_dict["target_values"], tree_dict["nodes"], tree_dict["features"])
 
 columns = recipe_config["inputColumns"] if recipe_config["keepSomeColumns"] else None
-scored_dataset.write_schema(get_scored_df_schema(tree, input_dataset, columns, recipe_config["outputProbabilities"]))
+scored_dataset.write_schema(get_scored_df_schema(tree, input_dataset.read_schema(), columns, recipe_config["outputProbabilities"]))
 writer = scored_dataset.get_writer()
 for df in input_dataset.iter_dataframes(chunksize=recipe_config["chunkSize"]):
     add_scoring_columns(tree, df, recipe_config["outputProbabilities"])

--- a/custom-recipes/decision-tree-builder-tree-scoring/recipe.py
+++ b/custom-recipes/decision-tree-builder-tree-scoring/recipe.py
@@ -1,19 +1,26 @@
 from dataiku.customrecipe import get_input_names_for_role, get_output_names_for_role, get_recipe_config
-from dku_idtb_decision_tree.tree import Tree
-from dku_idtb_scoring.score import score, write_with_schema
+from dku_idtb_decision_tree.tree import ScoringTree
+from dku_idtb_scoring.score import add_scoring_columns, get_scored_df_schema
 
-input_dataset = dataiku.Dataset(get_input_names_for_role("input_dataset")[0])
-scored_dataset = dataiku.Dataset(get_output_names_for_role("scored_dataset")[0])
+input_dataset = dataiku.Dataset(get_input_names_for_role("inputDataset")[0])
+scored_dataset = dataiku.Dataset(get_output_names_for_role("scoredDataset")[0])
 folder = dataiku.Folder(get_input_names_for_role("folder")[0])
-chunk_size_param = get_recipe_config()["chunk_size"]
+recipe_config = get_recipe_config()
 
 try:
-    tree = folder.read_json(get_recipe_config()["tree_file"])
+    tree_dict = folder.read_json(recipe_config["treeFile"])
 except ValueError:
-    raise Exception("No tree file named " + get_recipe_config()["tree_file"])
+    raise Exception("No tree file named " + recipe_config["treeFile"])
 
-tree["df"] = input_dataset.get_dataframe()
-tree = Tree(**tree)
+tree = ScoringTree(tree_dict["target"], tree_dict["target_values"], tree_dict["nodes"], tree_dict["features"])
 
-scored_df = score(tree, input_dataset, chunk_size_param, False)
-write_with_schema(tree, input_dataset, scored_dataset, scored_df, True, False)
+columns = recipe_config["inputColumns"] if recipe_config["keepSomeColumns"] else None
+scored_dataset.write_schema(get_scored_df_schema(tree, input_dataset, columns, recipe_config["outputProbabilities"]))
+writer = scored_dataset.get_writer()
+for df in input_dataset.iter_dataframes(chunksize=recipe_config["chunkSize"]):
+    add_scoring_columns(tree, df, recipe_config["outputProbabilities"])
+    if columns is None:
+        writer.write_dataframe(df)
+    else:
+        writer.write_dataframe(df[columns])
+writer.close()

--- a/python-lib/dku_idtb_decision_tree/node.py
+++ b/python-lib/dku_idtb_decision_tree/node.py
@@ -45,11 +45,9 @@ class Node(object):
     def get_type(self):
         raise NotImplementedError
 
-    def rebuild(self, children_ids, prediction, samples, probabilities, label=None):
-        self.children_ids += children_ids
+    def rebuild(self, prediction, samples, probabilities):
         self.prediction = prediction
         self.samples = samples
-        self.label = label
         self.probabilities = probabilities
 
     def jsonify(self):

--- a/python-lib/dku_idtb_decision_tree/tree.py
+++ b/python-lib/dku_idtb_decision_tree/tree.py
@@ -103,17 +103,16 @@ class InteractiveTree(Tree):
 
     sample_size: positive integer, the number of rows for the sampling
     """
-    def __init__(self, df, name, target, target_values=None, sample_method='head', sample_size=None, nodes=None, last_index=1,
+    def __init__(self, df, name, target, sample_method='head', sample_size=None, nodes=None, last_index=1,
                  features=None):
         try:
             df = df.dropna(subset=[target])
             df.loc[:, target] = df.loc[:, target].apply(safe_str) # for classification
         except KeyError:
             raise Exception("The target %s is not one of the columns of the dataset" % target)
-        if target_values is None:
-            target_values = list(df[target].unique())
+        target_values = list(df[target].unique())
         if features is None:
-            features, numerical_feature_set = Tree.get_features_with_meanings(df, target)
+            features, numerical_feature_set = InteractiveTree.get_features_with_meanings(df, target)
         super(InteractiveTree, self).__init__(target, target_values, features)
         self.df = df
         self.name = name
@@ -376,7 +375,6 @@ class InteractiveTree(Tree):
         return {"name": self.name,
                 "last_index": self.last_index,
                 "target": self.target,
-                "target_values": self.target_values,
                 "features": self.features,
                 "nodes": self.jsonify_nodes(),
                 "sample_method": self.sample_method,

--- a/python-lib/dku_idtb_decision_tree/tree.py
+++ b/python-lib/dku_idtb_decision_tree/tree.py
@@ -5,6 +5,79 @@ import pandas as pd
 
 
 class Tree(object):
+    def __init__(self, target, target_values, features):
+        self.target = target
+        self.target_values = target_values
+        self.features = features
+        self.nodes = {}
+        self.leaves = set()
+
+    def get_node(self, i):
+        return self.nodes.get(i)
+
+    def add_node(self, node):
+        self.nodes[node.id] = node
+        self.leaves.add(node.id)
+        self.leaves.discard(node.parent_id)
+
+    def get_filtered_df(self, node, df):
+        node_id = node.id
+        while node_id > 0:
+            node = self.get_node(node_id)
+            if node.get_type() == Node.TYPES.NUM:
+                df = node.apply_filter(df, self.features[node.feature]["mean"])
+            else:
+                df = node.apply_filter(df)
+            node_id = node.parent_id
+        return df
+
+    def parse_nodes(self, nodes, rebuild_nodes=False):
+        self.nodes, ids = {}, deque()
+        root_node_dict = nodes["0"]
+        root_node = Node(0, -1, set(root_node_dict["treated_as_numerical"]))
+        root_node.label = root_node_dict["label"]
+        self.add_node(root_node)
+
+        ids += root_node_dict["children_ids"]
+
+        while ids:
+            dict_node = nodes[safe_str(ids.popleft())]
+            if dict_node.get("values") is not None:
+                node = CategoricalNode(dict_node["id"],
+                                       dict_node["parent_id"],
+                                       set(dict_node["treated_as_numerical"]),
+                                       dict_node["feature"],
+                                       dict_node["values"],
+                                       others=dict_node["others"])
+            else:
+                node = NumericalNode(dict_node["id"],
+                                     dict_node["parent_id"],
+                                     set(dict_node["treated_as_numerical"]),
+                                     dict_node["feature"],
+                                     beginning=dict_node.get("beginning", None),
+                                     end=dict_node.get("end", None))
+            node.label = dict_node["label"]
+            self.add_node(node)
+            if rebuild_nodes:
+                node.rebuild(dict_node["prediction"],
+                            dict_node["samples"],
+                            dict_node["probabilities"])
+            ids += dict_node["children_ids"]
+
+# Used by the recipes
+class ScoringTree(Tree):
+    def __init__(self, target, target_values, nodes, features):
+        super(ScoringTree, self).__init__(target, target_values, features)
+        self.parse_nodes(nodes, True)
+
+    def add_node(self, node):
+        parent_node = self.get_node(node.parent_id)
+        if parent_node is not None:
+            parent_node.children_ids.append(node.id)
+        super(ScoringTree, self).add_node(node)
+
+#Used by the webapp
+class InteractiveTree(Tree):
     """
     A decision tree
 
@@ -31,37 +104,28 @@ class Tree(object):
     sample_size: positive integer, the number of rows for the sampling
     """
     def __init__(self, df, name, target, target_values=None, sample_method='head', sample_size=None, nodes=None, last_index=1,
-                 features=None, new_sampling=False):
+                 features=None):
         try:
             df = df.dropna(subset=[target])
             df.loc[:, target] = df.loc[:, target].apply(safe_str) # for classification
-            self.df = df
         except KeyError:
             raise Exception("The target %s is not one of the columns of the dataset" % target)
+        if target_values is None:
+            target_values = list(df[target].unique())
+        if features is None:
+            features, numerical_feature_set = Tree.get_features_with_meanings(df, target)
+        super(InteractiveTree, self).__init__(target, target_values, features)
+        self.df = df
         self.name = name
         self.last_index = last_index
-        self.target = target
-        if target_values is None:
-            self.target_values = list(self.df[target].unique())
-        else:
-            self.target_values = target_values
         self.sample_method = sample_method
         self.sample_size = sample_size
-        self.leaves = set()
         if nodes is None:
-            self.nodes = {}
             root = Node(0, -1, set())
-            self.add_node(root, None)
+            root.treated_as_numerical = numerical_feature_set
+            self.add_node(root)
         else:
             self.parse_nodes(nodes)
-        if features is None:
-            self.features = {}
-            self.get_features_with_meanings(df)
-        else:
-            self.features = features
-        if new_sampling:
-            for node in self.nodes.values():
-                self.set_node_info(node)
 
     def change_meaning(self, i, feature):
         node = self.get_node(i)
@@ -70,17 +134,6 @@ class Tree(object):
         else:
             node.treated_as_numerical.add(feature)
         return self.get_stats(i, feature)
-
-    def get_filtered_df(self, node, df):
-        node_id = node.id
-        while node_id > 0:
-            node = self.get_node(node_id)
-            if node.get_type() == Node.TYPES.NUM:
-                df = node.apply_filter(df, self.features[node.feature]["mean"])
-            else:
-                df = node.apply_filter(df)
-            node_id = node.parent_id
-        return df
 
     def get_stats(self, i, col):
         node = self.get_node(i)
@@ -165,7 +218,7 @@ class Tree(object):
         if right is None:
             new_node = NumericalNode(self.last_index, parent_node.id, set(parent_node.treated_as_numerical), feature, beginning=value)
             self.last_index += 1
-            self.add_node(new_node, parent_node)
+            self.add_node(new_node)
             self.update_numerical_node(left, value, True)
             return {"left": left.jsonify(), "right": new_node.jsonify(), "parent": parent_node.jsonify()}
 
@@ -175,18 +228,17 @@ class Tree(object):
             self.kill_children(right)
             new_node.beginning = left.end
         self.update_numerical_node(right, value, False)
-        self.add_node(new_node, parent_node, right_idx)
+        self.add_node(new_node, right_idx)
         return {"left": new_node.jsonify(), "right": right.jsonify(), "parent": parent_node.jsonify()}
 
     def add_numerical_split_no_siblings(self, parent_node, feature, value):
-        self.leaves.remove(parent_node.id)
         self.features[feature]["nr_uses"] += 1
         new_node_left = NumericalNode(self.last_index, parent_node.id, set(parent_node.treated_as_numerical), feature, end=value)
         self.last_index += 1
         new_node_right = NumericalNode(self.last_index, parent_node.id, set(parent_node.treated_as_numerical), feature, beginning=value)
         self.last_index += 1
-        self.add_node(new_node_left, parent_node)
-        self.add_node(new_node_right, parent_node)
+        self.add_node(new_node_left)
+        self.add_node(new_node_right)
         return {"left": new_node_left.jsonify(), "right": new_node_right.jsonify(), "parent": parent_node.jsonify()}
 
     def add_categorical_split(self, parent_node, feature, values):
@@ -195,14 +247,13 @@ class Tree(object):
         if not parent_node.children_ids:
             self.features[feature]["nr_uses"] += 1
             right = CategoricalNode(self.last_index, parent_node.id, set(parent_node.treated_as_numerical), feature, list(values), others=True)
-            self.leaves.remove(parent_node.id)
             self.last_index += 1
         else:
             right = self.get_node(parent_node.children_ids.pop())
             self.update_categorical_node(right, values, None)
 
-        self.add_node(left, parent_node)
-        self.add_node(right, parent_node)
+        self.add_node(left)
+        self.add_node(right)
         return {"left": left.jsonify(), "right": right.jsonify(), "parent": parent_node.jsonify()}
 
     def update_split(self, feature, left_id, right_id, value):
@@ -290,18 +341,15 @@ class Tree(object):
                 self.update_categorical_node(right, None, left.values)
         return self.jsonify_nodes()
 
-    def add_node(self, node, parent_node, idx=None):
-        self.nodes[node.id] = node
-        self.leaves.add(node.id)
-        self.set_node_info(node)
+    def add_node(self, node, idx=None):
+        parent_node = self.get_node(node.parent_id)
         if parent_node is not None:
             if idx is None:
                 parent_node.children_ids.append(node.id)
             else:
                 parent_node.children_ids.insert(idx, node.id)
-
-    def get_node(self, i):
-        return self.nodes.get(i)
+        self.set_node_info(node)
+        super(InteractiveTree, self).add_node(node)
 
     def delete_node(self, node, parent_node):
         self.kill_children(node)
@@ -324,40 +372,6 @@ class Tree(object):
                 self.leaves.remove(index)
             del self.nodes[index]
 
-    def parse_nodes(self, nodes):
-        self.nodes, ids = {}, deque()
-        node = Node(0, -1, set(nodes["0"]["treated_as_numerical"]))
-        node.rebuild(nodes["0"]["children_ids"],
-                     nodes["0"]["prediction"], nodes["0"]["samples"],
-                     nodes["0"]["probabilities"],
-                     nodes["0"]["label"])
-        self.nodes[0] = node
-
-        ids += node.children_ids
-        if not ids:
-            self.leaves.add(node.id)
-        while ids:
-            dict_node = nodes[safe_str(ids.popleft())]
-            if dict_node.get("values") is not None:
-                node = CategoricalNode(dict_node.pop("id"),
-                                       dict_node.pop("parent_id"),
-                                       set(dict_node.pop("treated_as_numerical")),
-                                       dict_node.pop("feature"),
-                                       dict_node.pop("values"),
-                                       others=dict_node.pop("others"))
-            else:
-                node = NumericalNode(dict_node.pop("id"),
-                                     dict_node.pop("parent_id"),
-                                     set(dict_node.pop("treated_as_numerical")),
-                                     dict_node.pop("feature"),
-                                     beginning=dict_node.pop("beginning", None),
-                                     end=dict_node.pop("end", None))
-            node.rebuild(**dict_node)
-            if not node.children_ids:
-                self.leaves.add(node.id)
-            self.nodes[node.id] = node
-            ids += node.children_ids
-
     def jsonify(self):
         return {"name": self.name,
                 "last_index": self.last_index,
@@ -374,13 +388,15 @@ class Tree(object):
             jsonified_tree[key] = node.jsonify()
         return jsonified_tree
 
-
-    def get_features_with_meanings(self, df):
+    @staticmethod
+    def get_features_with_meanings(df, target):
+        feature_dict, numerical_feature_set = {}, set()
         for col_name in df.columns:
-            if col_name != self.target:
-                self.features[col_name] = {"nr_uses": 0}
+            if col_name != target:
+                feature_dict[col_name] = {"nr_uses": 0}
                 col = df.loc[:, col_name]
                 if pd.api.types.is_numeric_dtype(col):
                     if col.nunique() > 10:
-                        self.features[col_name]["mean"] = col.mean()
-                        self.get_node(0).treated_as_numerical.add(col_name)
+                        feature_dict[col_name]["mean"] = col.mean()
+                        numerical_feature_set.add(col_name)
+        return feature_dict, numerical_feature_set

--- a/python-lib/dku_idtb_scoring/score.py
+++ b/python-lib/dku_idtb_scoring/score.py
@@ -17,8 +17,7 @@ def update_input_schema(input_schema, columns):
             new_input_schema.append(column)
     return new_input_schema
 
-def get_scored_df_schema(tree, input_dataset, columns, output_probabilities, is_evaluation=False, check_prediction=False):
-    schema = input_dataset.read_schema()
+def get_scored_df_schema(tree, schema, columns, output_probabilities, is_evaluation=False, check_prediction=False):
     check_input_schema(tree, set(column["name"] for column in schema), is_evaluation)
     if columns is not None:
         schema = update_input_schema(schema, columns)
@@ -59,6 +58,7 @@ def add_scoring_columns(tree, df, output_probabilities, is_evaluation=False, che
         leaf = tree.get_node(leaf_id)
         if leaf.prediction is not None:
             filtered_df = tree.get_filtered_df(leaf, df)
+            label_indices = filtered_df.index
             if is_evaluation:
                 filtered_df = filtered_df[filtered_df[tree.target].isin(tree.target_values)]
             filtered_df_indices = filtered_df.index
@@ -74,7 +74,7 @@ def add_scoring_columns(tree, df, output_probabilities, is_evaluation=False, che
             df.loc[filtered_df_indices, "prediction"] = leaf.prediction
             if check_prediction:
                 df.loc[filtered_df_indices, "prediction_correct"] = filtered_df[tree.target] == leaf.prediction
-            df.loc[filtered_df_indices, "label"] = leaf.label
+            df.loc[label_indices, "label"] = leaf.label
 
         elif leaf.label is not None:
             filtered_df = tree.get_filtered_df(leaf, df)

--- a/python-lib/dku_idtb_scoring/score.py
+++ b/python-lib/dku_idtb_scoring/score.py
@@ -1,50 +1,81 @@
 import pandas as pd
 from dku_idtb_compatibility.utils import safe_str
 
-def check(df, tree, check_prediction):
+def check_input_schema(tree, col_set, check_prediction):
     for col_name, col_usage in tree.features.items():
         if col_usage["nr_uses"] > 0:
-            if col_name not in df.columns:
+            if col_name not in col_set:
                 raise ValueError("The column %s is missing in the input dataset" % col_name)
+    if check_prediction and tree.target not in col_set:
+        raise ValueError("The target %s is missing in the input dataset" % tree.target)
 
-def score_chunk(tree, df, check_prediction):
-    filtered_dfs = []
-    for leaf_id in tree.leaves:
-        leaf = tree.get_node(leaf_id)
-        filtered_df = tree.get_filtered_df(leaf, df)
-        for proba in leaf.probabilities:
-            filtered_df["proba_" + safe_str(proba[0])] = proba[1]
-        filtered_df["prediction"] = leaf.prediction
-        if check_prediction and leaf.prediction is not None:
-            filtered_df["prediction_correct"] = filtered_df[tree.target].apply(safe_str) == leaf.prediction
-        filtered_df["label"] = leaf.label
-        filtered_dfs.append(filtered_df)
-    return filtered_dfs
+def update_input_schema(input_schema, columns):
+    col_set = set(columns)
+    new_input_schema = []
+    for column in input_schema:
+        if column["name"] in col_set:
+            new_input_schema.append(column)
+    return new_input_schema
 
-def score(tree, input_dataset, chunk_size_param, check_prediction):
-    dfs = []
-    first_chunk = True
-    for df in input_dataset.iter_dataframes(chunksize=chunk_size_param):
-        if first_chunk:
-            check(df, tree, check_prediction)
-            first_chunk = False
-        dfs += score_chunk(tree, df, check_prediction)
-    full_df = pd.concat(dfs).sort_index()
-    proba_columns = ["proba_" + safe_str(target_value) for target_value in tree.target_values]
-    full_df[proba_columns] = full_df[proba_columns].fillna(0)
-    return full_df
-
-def write_with_schema(tree, input_dataset, scored_dataset, scored_df, output_probabilities, check_prediction):
+def get_scored_df_schema(tree, input_dataset, columns, output_probabilities, is_evaluation=False, check_prediction=False):
     schema = input_dataset.read_schema()
+    check_input_schema(tree, set(column["name"] for column in schema), is_evaluation)
+    if columns is not None:
+        schema = update_input_schema(schema, columns)
     if output_probabilities:
         for value in tree.target_values:
             schema.append({'type': 'double', 'name': "proba_" + safe_str(value)})
+            if columns is not None:
+                columns.append("proba_"+safe_str(value))
     schema.append({'type': 'string', 'name': 'prediction'})
+    if columns is not None:
+        columns.append("prediction")
     if check_prediction:
         schema.append({'type': 'boolean', 'name': 'prediction_correct'})
+        if columns is not None:
+            columns.append("prediction_correct")
     schema.append({'type': 'string', 'name': 'label'})
+    if columns is not None:
+        columns.append("label")
+    return schema
 
-    scored_dataset.write_schema(schema)
+def get_metric_df_schema(metrics_dict, metrics, recipe_config):
+    schema_metrics = []
+    for metric in metrics:
+        if metric == "mcalibrationLoss":
+            metric_name_in_config = "calibrationLoss"
+        elif metric == "mrocAUC":
+            metric_name_in_config = "auc"
+        else:
+            metric_name_in_config = metric
+        if recipe_config["filterMetrics"] and not recipe_config[metric_name_in_config]:
+            metrics_dict.pop(metric, "None")
+        else:
+            schema_metrics.append({"type": "float", "name": metric})
+    return schema_metrics
 
-    with scored_dataset.get_writer() as writer:
-        writer.write_dataframe(scored_df)
+def add_scoring_columns(tree, df, output_probabilities, is_evaluation=False, check_prediction=False):
+    for leaf_id in tree.leaves:
+        leaf = tree.get_node(leaf_id)
+        if leaf.prediction is not None:
+            filtered_df = tree.get_filtered_df(leaf, df)
+            if is_evaluation:
+                filtered_df = filtered_df[filtered_df[tree.target].isin(tree.target_values)]
+            filtered_df_indices = filtered_df.index
+
+            if output_probabilities:
+                remaining_target_classes = set(tree.target_values)
+                for target_class_name, proba in leaf.probabilities:
+                    df.loc[filtered_df_indices, "proba_"+safe_str(target_class_name)] = proba
+                    remaining_target_classes.remove(target_class_name)
+                for target_class_name in remaining_target_classes:
+                    df.loc[filtered_df_indices, "proba_"+safe_str(target_class_name)] = proba
+
+            df.loc[filtered_df_indices, "prediction"] = leaf.prediction
+            if check_prediction:
+                df.loc[filtered_df_indices, "prediction_correct"] = filtered_df[tree.target] == leaf.prediction
+            df.loc[filtered_df_indices, "label"] = leaf.label
+
+        elif leaf.label is not None:
+            filtered_df = tree.get_filtered_df(leaf, df)
+            df.loc[filtered_df.index, "label"] = leaf.label

--- a/python-lib/dku_idtb_scoring/score.py
+++ b/python-lib/dku_idtb_scoring/score.py
@@ -69,7 +69,7 @@ def add_scoring_columns(tree, df, output_probabilities, is_evaluation=False, che
                     df.loc[filtered_df_indices, "proba_"+safe_str(target_class_name)] = proba
                     remaining_target_classes.remove(target_class_name)
                 for target_class_name in remaining_target_classes:
-                    df.loc[filtered_df_indices, "proba_"+safe_str(target_class_name)] = proba
+                    df.loc[filtered_df_indices, "proba_"+safe_str(target_class_name)] = 0
 
             df.loc[filtered_df_indices, "prediction"] = leaf.prediction
             if check_prediction:

--- a/python-tests/test_score.py
+++ b/python-tests/test_score.py
@@ -1,109 +1,131 @@
 import pandas as pd
-from dku_idtb_scoring.score import score_chunk
-from dku_idtb_decision_tree.tree import Tree
+from dku_idtb_scoring.score import add_scoring_columns, get_scored_df_schema
+from dku_idtb_decision_tree.tree import ScoringTree
+from pytest import raises
 
-tree_dict = {
-	"name": "name",
-	"last_index": 3,
-	"target": "target",
-	"target_values": ["A", "B"],
-	"features": {
-              "num": {"nr_uses": 1, "mean": 3.5}
+nodes = {
+	"0": {
+		"id": 0,
+		"parent_id": -1,
+		"treated_as_numerical": {"num": None},
+		"feature": None,
+		"prediction": "A",
+		"children_ids": [1,2],
+		"probabilities": [["A", 0.664], ["B", 0.336]],
+		"samples": 500,
+		"label": None
 	},
-	"nodes": {
-		"0": {
-			"id": 0,
-			"parent_id": -1,
-			"treated_as_numerical": {"num": None},
-			"feature": None,
-			"prediction": "A",
-			"children_ids": [1,2],
-			"probabilities": [["A", 0.664], ["B", 0.336]],
-			"samples": 500,
-			"label": None
-		},
-		"1": {
-			"id": 1,
-			"parent_id": 0,
-			"treated_as_numerical": {"num": None},
-			"feature": "num",
-			"end": 4,
-			"prediction": "A",
-			"children_ids": [],
-			"probabilities": [["A", 0.800], ["B", 0.200]],
-			"samples": 300,
-			"label": "hello there"
-		},
-		"2": {
-			"id": 2,
-			"parent_id": 0,
-			"treated_as_numerical": {"num": None},
-			"feature": "num",
-			"beginning": 4,
-			"prediction": "A",
-			"children_ids": [3,4],
-			"probabilities": [["A", 0.800], ["B", 0.200]],
-			"samples": 200,
-			"label": None
-		},
-		"3": {
-			"id": 3,
-			"parent_id": 2,
-			"treated_as_numerical": {"num": None},
-			"feature": "cat",
-			"values": ["u"],
-			"prediction": "B",
-			"others": False,
-			"children_ids": [],
-			"probabilities": [["B", 0.75], ["A", 0.25]],
-			"samples": 100,
-			"label": "general Kenobi"
-		},
-		"4": {
-			"id": 4,
-			"parent_id": 2,
-			"treated_as_numerical": {"num": None},
-			"feature": "cat",
-			"values": ["u"],
-			"others": True,
-			"prediction": "B",
-			"children_ids": [],
-			"probabilities": [["B", 0.75], ["A", 0.25]],
-			"samples": 100,
-			"label": None
-		}
+	"1": {
+		"id": 1,
+		"parent_id": 0,
+		"treated_as_numerical": {"num": None},
+		"feature": "num",
+		"end": 4,
+		"prediction": "A",
+		"children_ids": [],
+		"probabilities": [["A", 0.800], ["B", 0.200]],
+		"samples": 300,
+		"label": "hello there"
 	},
-	"sample_method": "head",
-	"sample_size": 10000
+	"2": {
+		"id": 2,
+		"parent_id": 0,
+		"treated_as_numerical": {"num": None},
+		"feature": "num",
+		"beginning": 4,
+		"prediction": "A",
+		"children_ids": [3,4],
+		"probabilities": [["A", 0.800], ["B", 0.200]],
+		"samples": 200,
+		"label": None
+	},
+	"3": {
+		"id": 3,
+		"parent_id": 2,
+		"treated_as_numerical": {"num": None},
+		"feature": "cat",
+		"values": ["u","v"],
+		"prediction": "B",
+		"others": False,
+		"children_ids": [],
+		"probabilities": [["B", 0.75], ["A", 0.25]],
+		"samples": 0,
+		"label": None
+	},
+	"4": {
+		"id": 4,
+		"parent_id": 2,
+		"treated_as_numerical": {"num": None},
+		"feature": "cat",
+		"values": ["u", "v"],
+		"others": True,
+		"prediction": None,
+		"children_ids": [],
+		"probabilities": None,
+		"samples": 200,
+		"label": "general Kenobi"
+	}
 }
+features = {"num": {"nr_uses": 1, "mean": 3.5}, "cat": {"nr_uses": 1}}
+tree = ScoringTree("target", ["A", "B"], nodes, features)
 
-df = pd.DataFrame([[.2, "u", "A"],
-                    [7, pd.np.nan, "B"],
-                    [4, "u", "A"],
-                    [3, "v", "A"],
-                    [pd.np.nan, "u", "B"]], columns=("num", "cat", "target"))
-
-expected_chunk_1 = pd.DataFrame([[.2, "u", "A", .8, .2, "A", True, "hello there"],
-                                [3, "v", "A", .8, .2, "A", True, "hello there"],
-                                [pd.np.nan, "u", "B", .8, .2, "A", False, "hello there"]],
-                                columns=("num", "cat", "target", "proba_A", "proba_B", "prediction", "prediction_correct", "label"))
-expected_chunk_2 = pd.DataFrame([[4, "u", "A", .25, .75, "B", False, "general Kenobi"]],
-                                columns=("num", "cat", "target", "proba_A", "proba_B", "prediction", "prediction_correct",  "label"))
-expected_chunk_3 = pd.DataFrame([[7, pd.np.nan, "B", .25, .75, "B", True, pd.np.nan]],
-                                columns=("num", "cat", "target", "proba_A", "proba_B", "prediction", "prediction_correct", "label"))
-
-expected_chunk_1.index = [0,3,4]
-expected_chunk_2.index = [2]
-expected_chunk_3.index = [1]
-
-def check_equal(x, y):
-    return x.combine(y, lambda x,y: x==y if not pd.isna(x) else pd.isna(y)).all()
+def get_input_df():
+	return pd.DataFrame([[.2, "u", "A"],
+						[7, pd.np.nan, "B"],
+						[4, "u", "A"],
+						[3, "v", "A"],
+						[pd.np.nan, "u", "C"]], columns=("num", "cat", "target"))
 
 def test_score():
-    tree = Tree(pd.DataFrame(columns=["target"]), **tree_dict)
-    chunk_1, chunk_2, chunk_3 = score_chunk(tree, df, True)
-    expected_chunk_1.index = [0,3,4]
+	df = get_input_df()
+	add_scoring_columns(tree, df, True)
+	expected_df = pd.DataFrame([[.2, "u", "A", .8, .2, "A", "hello there"],
+								[7, pd.np.nan, "B", pd.np.nan, pd.np.nan, pd.np.nan, "general Kenobi"],
+								[4, "u", "A", .25, .75, "B", None],
+								[3, "v", "A", .8, .2, "A", "hello there"],
+								[pd.np.nan, "u", "C", .8, .2, "A", "hello there"]], columns=("num", "cat", "target", "proba_A", "proba_B", "prediction", "label"))
+	assert df.equals(expected_df)
 
-    assert chunk_1.combine(expected_chunk_1, check_equal).all(axis=None)
-    assert chunk_2.combine(expected_chunk_2, check_equal).all(axis=None)
-    assert chunk_3.combine(expected_chunk_3, check_equal).all(axis=None)
+	df = get_input_df()
+	add_scoring_columns(tree, df, False, True, False)
+	expected_df = pd.DataFrame([[.2, "u", "A", "A", "hello there"],
+								[7, pd.np.nan, "B", pd.np.nan, "general Kenobi"],
+								[4, "u", "A", "B", None],
+								[3, "v", "A", "A", "hello there"],
+								[pd.np.nan, "u", "C", pd.np.nan, "hello there"]], columns=("num", "cat", "target", "prediction", "label"))
+	assert df.equals(expected_df)
+
+	df = get_input_df()
+	add_scoring_columns(tree, df, False, True, True)
+	expected_df = pd.DataFrame([[.2, "u", "A", "A", True, "hello there"],
+								[7, pd.np.nan, "B", pd.np.nan, pd.np.nan, "general Kenobi"],
+								[4, "u", "A", "B", False, None],
+								[3, "v", "A", "A", True, "hello there"],
+								[pd.np.nan, "u", "C", pd.np.nan, pd.np.nan, "hello there"]], columns=("num", "cat", "target", "prediction", "prediction_correct", "label"))
+	assert df.equals(expected_df)
+
+def get_input_schema():
+	return [{"type": "double", "name": "num"}, {"type": "string", "name": "cat"}, {"type": "string", "name": "target"}]
+
+def test_scored_df_schema():
+	schema = get_scored_df_schema(tree, get_input_schema(), None, True)
+	assert schema == [{"type": "double", "name": "num"}, {"type": "string", "name": "cat"}, {"type": "string", "name": "target"},
+					{"type": "double", "name": "proba_A"}, {"type": "double", "name": "proba_B"}, {"type": "string", "name": "prediction"}, {"type": "string", "name": "label"}]
+	columns = []
+	schema = get_scored_df_schema(tree, get_input_schema(), columns, False, True, False)
+	assert schema == [{"type": "string", "name": "prediction"}, {"type": "string", "name": "label"}]
+	assert columns == ["prediction", "label"]
+
+	columns = ["num"]
+	schema = get_scored_df_schema(tree, get_input_schema(), columns, False, True, True)
+	assert schema == [{"type": "double", "name": "num"}, {"type": "string", "name": "prediction"}, {"type": "boolean", "name": "prediction_correct"}, {"type": "string", "name": "label"}]
+	assert columns == ["num", "prediction", "prediction_correct", "label"]
+
+	schema_missing_feature = [{"type": "double", "name": "num"}, {"type": "string", "name": "target"}]
+	schema_missing_target = [{"type": "double", "name": "num"}, {"type": "string", "name": "cat"}]
+	with raises(ValueError) as e:
+		get_scored_df_schema(tree, schema_missing_feature, None, False)
+		assert e.args[0] == "The column cat is missing in the input dataset"
+	with raises(ValueError) as e:
+		get_scored_df_schema(tree, schema_missing_target, None, False, True, True)
+		assert e.args[0] == "The target target is missing in the input dataset"

--- a/python-tests/test_tree.py
+++ b/python-tests/test_tree.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from dku_idtb_decision_tree.tree import Tree
+from dku_idtb_decision_tree.tree import InteractiveTree
 
 df = pd.DataFrame([
                     [1, 5.5, "x", "n", "A"],
@@ -17,7 +17,7 @@ df = pd.DataFrame([
                 ], columns=("num_1", "num_2", "cat_1", "cat_2", "target"))
 
 def test_get_stats():
-    tree = Tree(df, None, "target")
+    tree = InteractiveTree(df, None, "target")
     stats_num_col = tree.get_stats(0, "num_1")
     assert stats_num_col["mean"] == 6
     assert stats_num_col["max"] == 11
@@ -36,7 +36,7 @@ def test_get_stats():
                                     {"value": "y", "count": 3, "target_distrib": {"A": 1, "B": 1, "C": 1}}]
     assert stats_cat_col.get("same_target_distrib") is None
 
-    tree = Tree(df.head(4), None, "target")
+    tree = InteractiveTree(df.head(4), None, "target")
     assert tree.get_stats(0, "cat_2")["same_target_distrib"]
 
 def check_node_info(node, samples, probabilities):
@@ -48,7 +48,7 @@ def check_node_info(node, samples, probabilities):
         assert node.prediction is None
 
 def test_on_categorical_splits():
-    tree = Tree(df, None, "target")
+    tree = InteractiveTree(df, None, "target")
     _test_add_categorical_nodes(tree)
     _test_update_categorical_nodes(tree)
     _test_delete_categorical_node(tree)
@@ -114,7 +114,7 @@ def _test_delete_categorical_node(tree):
     assert tree.get_node(2) is None and tree.get_node(3) is None
 
 def test_on_numerical_splits():
-    tree = Tree(df, None, "target")
+    tree = InteractiveTree(df, None, "target")
     _test_add_numerical_node(tree)
     _test_update_numerical_nodes(tree)
     _test_delete_numerical_node(tree)

--- a/webapps/interactive-decision-tree-builder/backend.py
+++ b/webapps/interactive-decision-tree-builder/backend.py
@@ -86,11 +86,10 @@ def load():
     try:
         data = json.loads(request.data)
         jsonified_tree = folder.read_json(data["filename"])
-        df = dataiku.Dataset(jsonified_tree["name"]).get_dataframe(sampling=data.get("sample_method", "head"),
-                                                                limit=data.get("sample_size"))
-        jsonified_tree["sample_method"] = data.get("sample_method", "head")
-        jsonified_tree["sample_size"] = data.get("sample_size")
-        tree = InteractiveTree(df, **jsonified_tree)
+        name, sample_method, sample_size = jsonified_tree["name"], data.get("sample_method", "head"), data.get("sample_size")
+        df = dataiku.Dataset(name).get_dataframe(sampling=sample_method, limit=sample_size)
+        tree = InteractiveTree(df, name, jsonified_tree["target"], sample_method, sample_size,
+                                jsonified_tree["nodes"], jsonified_tree["last_index"], jsonified_tree["features"])
         factory.set_tree(folder_name, tree)
         return jsonify(tree.jsonify())
     except:

--- a/webapps/interactive-decision-tree-builder/backend.py
+++ b/webapps/interactive-decision-tree-builder/backend.py
@@ -2,7 +2,7 @@ import dataiku
 from dataiku.customwebapp import get_webapp_config
 from flask import jsonify, request
 import traceback, json, logging
-from dku_idtb_decision_tree.tree import Tree
+from dku_idtb_decision_tree.tree import InteractiveTree
 from dku_idtb_decision_tree.tree_factory import TreeFactory
 from dku_idtb_decision_tree.node import Node
 from dku_idtb_decision_tree.autosplit import autosplit
@@ -64,7 +64,7 @@ def create():
     try:
         data = json.loads(request.data)
         df = dataiku.Dataset(data["name"]).get_dataframe(sampling=data.get("sample_method", "head"), limit=data.get("sample_size"))
-        tree = Tree(df, **data)
+        tree = InteractiveTree(df, **data)
         factory.set_tree(folder_name, tree)
         return jsonify(tree.jsonify())
     except:
@@ -86,14 +86,11 @@ def load():
     try:
         data = json.loads(request.data)
         jsonified_tree = folder.read_json(data["filename"])
-        new_sampling = data.get("sample_method") == "random" \
-            or data.get("sample_method") != jsonified_tree.get("sample_method") \
-            or data.get("sample_size") != jsonified_tree.get("sample_size")
         df = dataiku.Dataset(jsonified_tree["name"]).get_dataframe(sampling=data.get("sample_method", "head"),
                                                                 limit=data.get("sample_size"))
         jsonified_tree["sample_method"] = data.get("sample_method", "head")
         jsonified_tree["sample_size"] = data.get("sample_size")
-        tree = Tree(df, new_sampling=new_sampling, **jsonified_tree)
+        tree = InteractiveTree(df, **jsonified_tree)
         factory.set_tree(folder_name, tree)
         return jsonify(tree.jsonify())
     except:

--- a/webapps/interactive-decision-tree-builder/backend.py
+++ b/webapps/interactive-decision-tree-builder/backend.py
@@ -66,7 +66,7 @@ def create():
         df = dataiku.Dataset(data["name"]).get_dataframe(sampling=data.get("sample_method", "head"), limit=data.get("sample_size"))
         tree = InteractiveTree(df, **data)
         factory.set_tree(folder_name, tree)
-        return jsonify(tree.jsonify())
+        return jsonify(nodes=tree.jsonify_nodes(), target_values=tree.target_values, features=tree.features)
     except:
         logger.error(traceback.format_exc())
         return traceback.format_exc(), 500
@@ -91,7 +91,7 @@ def load():
         tree = InteractiveTree(df, name, jsonified_tree["target"], sample_method, sample_size,
                                 jsonified_tree["nodes"], jsonified_tree["last_index"], jsonified_tree["features"])
         factory.set_tree(folder_name, tree)
-        return jsonify(tree.jsonify())
+        return jsonify(nodes=tree.jsonify_nodes(), target_values=tree.target_values, features=tree.features)
     except:
         logger.error(traceback.format_exc())
         return traceback.format_exc(), 500


### PR DESCRIPTION
Several enhancements on the scoring/evaluation recipes, most of them for consistency sake (regarding the preexisting Score/Evaluation recipes on saved models in DSS).

-  Scoring:
    - write the scored dataset by chunks
    - add parameters: ability to pick the input columns to keep; ability to choose whether to output the probabilities columns
    - fix behavior: if rows of the scored dataset match a leaf with a `prediction` equals to `None`, leave the prediction/probabilities columns empty. Label should be filled however

- Evaluation: 
   - remove the parameter chunksize as it is not used
   - add parameters: ability to pick the input columns to keep; ability to choose whether to output the probabilities columns; ability to choose whether to output `prediction_correct` column
    - fix behavior: if new values for the target classes are found in the scored dataset, unlike in the scoring recipe, do **not** compute prediction/probabilities/`prediction_correct` (leave these columns empty for these rows, same as in DSS). Label column should be filled however

This PR also does some modifications to `tree.py`:
- Add a new hierarchy: creating two new classes inheriting from `Tree` (`ScoringTree`, "lighter" class for recipes, and `InteractiveTree`, used for training in the Interactive Builder webapp).
- When loading a tree from a file in the webapp, its target values, and the stats of each one of its nodes is now always recomputed

Integration tests on the scoring lib and `Tree` class have been updated accordingly in `python-tests`.